### PR TITLE
Enforce uniqueness for DNS-related records

### DIFF
--- a/alembic/versions/202509271600_consolidated_schema.py
+++ b/alembic/versions/202509271600_consolidated_schema.py
@@ -67,6 +67,11 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "ip_address",
+            name="uq_a_records_domain_id_ip_address",
+        ),
     )
     op.create_index("ix_a_records_domain_id", "a_records", ["domain_id"], unique=False)
     op.create_index("ix_a_records_ip", "a_records", ["ip_address"], unique=False)
@@ -81,6 +86,11 @@ def upgrade() -> None:
         sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "ip_address",
+            name="uq_aaaa_records_domain_id_ip_address",
+        ),
     )
     op.create_index("ix_aaaa_records_domain_id", "aaaa_records", ["domain_id"], unique=False)
     op.create_index("ix_aaaa_records_ip", "aaaa_records", ["ip_address"], unique=False)
@@ -94,6 +104,11 @@ def upgrade() -> None:
         sa.Column("value", sa.String(length=255), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "value",
+            name="uq_ns_records_domain_id_value",
+        ),
     )
     op.create_index("ix_ns_records_domain_id", "ns_records", ["domain_id"], unique=False)
     op.create_index("ix_ns_records_value", "ns_records", ["value"], unique=False)
@@ -107,6 +122,11 @@ def upgrade() -> None:
         sa.Column("value", sa.String(length=255), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "value",
+            name="uq_soa_records_domain_id_value",
+        ),
     )
     op.create_index("ix_soa_records_domain_id", "soa_records", ["domain_id"], unique=False)
     op.create_index("ix_soa_records_value", "soa_records", ["value"], unique=False)
@@ -121,6 +141,12 @@ def upgrade() -> None:
         sa.Column("priority", sa.Integer(), nullable=True),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "exchange",
+            "priority",
+            name="uq_mx_records_domain_id_exchange_priority",
+        ),
     )
     op.create_index("ix_mx_records_domain_id", "mx_records", ["domain_id"], unique=False)
     op.create_index("ix_mx_records_exchange", "mx_records", ["exchange"], unique=False)
@@ -135,6 +161,11 @@ def upgrade() -> None:
         sa.Column("target", sa.String(length=255), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "target",
+            name="uq_cname_records_domain_id_target",
+        ),
     )
     op.create_index("ix_cname_records_domain_id", "cname_records", ["domain_id"], unique=False)
     op.create_index("ix_cname_records_target", "cname_records", ["target"], unique=False)
@@ -148,6 +179,11 @@ def upgrade() -> None:
         sa.Column("content", sa.String(length=1000), nullable=False),
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "content",
+            name="uq_txt_records_domain_id_content",
+        ),
     )
     op.create_index("ix_txt_records_domain_id", "txt_records", ["domain_id"], unique=False)
     op.create_index("ix_txt_records_updated_at", "txt_records", ["updated_at"], unique=False)
@@ -162,6 +198,11 @@ def upgrade() -> None:
         sa.Column("service", sa.String(length=255), nullable=True),  # Updated name and length
         sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
         sa.ForeignKeyConstraint(["domain_id"], ["domains.id"], ondelete="CASCADE"),
+        sa.UniqueConstraint(
+            "domain_id",
+            "port",
+            name="uq_port_services_domain_id_port",
+        ),
     )
     op.create_index("ix_port_services_domain_id", "port_services", ["domain_id"], unique=False)
     op.create_index("ix_port_services_port", "port_services", ["port"], unique=False)

--- a/app/models/postgres.py
+++ b/app/models/postgres.py
@@ -73,6 +73,11 @@ class Domain(SQLModel, table=True):
 
 class ARecord(SQLModel, table=True):
     __tablename__ = "a_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "ip_address", name="uq_a_records_domain_id_ip_address"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -85,6 +90,11 @@ class ARecord(SQLModel, table=True):
 
 class AAAARecord(SQLModel, table=True):
     __tablename__ = "aaaa_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "ip_address", name="uq_aaaa_records_domain_id_ip_address"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -97,6 +107,11 @@ class AAAARecord(SQLModel, table=True):
 
 class NSRecord(SQLModel, table=True):
     __tablename__ = "ns_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "value", name="uq_ns_records_domain_id_value"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -106,6 +121,11 @@ class NSRecord(SQLModel, table=True):
 
 class SoaRecord(SQLModel, table=True):
     __tablename__ = "soa_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "value", name="uq_soa_records_domain_id_value"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -115,6 +135,14 @@ class SoaRecord(SQLModel, table=True):
 
 class MXRecord(SQLModel, table=True):
     __tablename__ = "mx_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id",
+            "exchange",
+            "priority",
+            name="uq_mx_records_domain_id_exchange_priority",
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -127,6 +155,11 @@ class MXRecord(SQLModel, table=True):
 
 class CNAMERecord(SQLModel, table=True):
     __tablename__ = "cname_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "target", name="uq_cname_records_domain_id_target"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -138,6 +171,11 @@ class CNAMERecord(SQLModel, table=True):
 
 class TXTRecord(SQLModel, table=True):
     __tablename__ = "txt_records"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "content", name="uq_txt_records_domain_id_content"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)
@@ -149,6 +187,11 @@ class TXTRecord(SQLModel, table=True):
 
 class PortService(SQLModel, table=True):
     __tablename__ = "port_services"
+    __table_args__ = (
+        UniqueConstraint(
+            "domain_id", "port", name="uq_port_services_domain_id_port"
+        ),
+    )
 
     id: Optional[int] = Field(default=None, primary_key=True)
     domain_id: int = Field(foreign_key="domains.id", nullable=False)


### PR DESCRIPTION
## Summary
- add composite unique constraints to DNS-related tables in the consolidated Alembic schema
- mirror the unique constraints in the SQLModel ORM definitions to keep application logic in sync

## Testing
- pytest tests/test_postgres_integration.py

------
https://chatgpt.com/codex/tasks/task_e_68db852ec9b483239fd537566d8267a7