### PR TITLE
Refactor remaining tools to SQLModel

### DIFF
--- a/tools/import_records.py
+++ b/tools/import_records.py
@@ -6,173 +6,144 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
 
-import psycopg
+from sqlmodel import Session, select
 
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
-def _parse_env_file(path: Path) -> dict[str, str]:
-    env_vars: dict[str, str] = {}
-    if not path.exists():
-        return env_vars
-
-    with path.open("r", encoding="utf-8") as handle:
-        for raw_line in handle:
-            line = raw_line.strip()
-            if not line or line.startswith("#") or "=" not in line:
-                continue
-            key, value = line.split("=", 1)
-            env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def resolve_dsn(explicit: str | None = None) -> str:
-    if explicit:
-        dsn = explicit
-    elif "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        env_vars = _parse_env_file(ENV_PATH)
-        dsn = env_vars.get("POSTGRES_DSN")
-
-    if not dsn:
-        raise ValueError("POSTGRES_DSN not provided via flag, env var, or .env file")
-
-    if dsn.startswith("postgresql+asyncpg://"):
-        dsn = "postgresql://" + dsn[len("postgresql+asyncpg://") :]
-    elif dsn.startswith("postgresql+psycopg://"):
-        dsn = "postgresql://" + dsn[len("postgresql+psycopg://") :]
-    elif "://" not in dsn:
-        dsn = f"postgresql://{dsn}"
-
-    return dsn
+from app.models.postgres import (
+    AAAARecord,
+    ARecord,
+    CNAMERecord,
+    Domain,
+    MXRecord,
+    NSRecord,
+    SoaRecord,
+)
+from tools.sqlmodel_helpers import resolve_sync_dsn, session_scope
 
 
 def utcnow() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def ensure_domain(cur: psycopg.Cursor, domain: str, now: datetime) -> int:
-    cur.execute(
-        """
-        INSERT INTO domains (name, created_at, updated_at)
-        VALUES (%s, %s, %s)
-        ON CONFLICT (name) DO UPDATE
-        SET updated_at = EXCLUDED.updated_at
-        RETURNING id
-        """,
-        (domain, now, now),
+def ensure_domain(session: Session, domain: str, now: datetime) -> Domain:
+    statement = select(Domain).where(Domain.name == domain)
+    domain_obj = session.exec(statement).one_or_none()
+    if domain_obj:
+        domain_obj.updated_at = now
+    else:
+        domain_obj = Domain(name=domain, created_at=now, updated_at=now)
+
+    session.add(domain_obj)
+    session.flush()
+    return domain_obj
+
+
+def insert_a_record(session: Session, domain_id: int, value: str, now: datetime) -> bool:
+    statement = select(ARecord).where(
+        ARecord.domain_id == domain_id,
+        ARecord.ip_address == value,
     )
-    row = cur.fetchone()
-    if not row:
-        raise RuntimeError(f"Failed to ensure domain {domain}")
-    return int(row[0])
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
 
-
-def insert_a_record(cur: psycopg.Cursor, domain_id: int, value: str, now: datetime) -> bool:
-    cur.execute(
-        """
-        INSERT INTO a_records (domain_id, ip_address, created_at, updated_at)
-        SELECT %s, %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM a_records WHERE domain_id = %s AND ip_address = %s
+    session.add(
+        ARecord(
+            domain_id=domain_id,
+            ip_address=value,
+            created_at=now,
+            updated_at=now,
         )
-        """,
-        (domain_id, value, now, now, domain_id, value),
     )
-    return cur.rowcount == 1
+    return True
 
 
-def insert_aaaa_record(cur: psycopg.Cursor, domain_id: int, value: str, now: datetime) -> bool:
-    cur.execute(
-        """
-        INSERT INTO aaaa_records (domain_id, ip_address, created_at, updated_at)
-        SELECT %s, %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM aaaa_records WHERE domain_id = %s AND ip_address = %s
+def insert_aaaa_record(session: Session, domain_id: int, value: str, now: datetime) -> bool:
+    statement = select(AAAARecord).where(
+        AAAARecord.domain_id == domain_id,
+        AAAARecord.ip_address == value,
+    )
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
+
+    session.add(
+        AAAARecord(
+            domain_id=domain_id,
+            ip_address=value,
+            created_at=now,
+            updated_at=now,
         )
-        """,
-        (domain_id, value, now, now, domain_id, value),
     )
-    return cur.rowcount == 1
+    return True
 
 
-def insert_ns_record(cur: psycopg.Cursor, domain_id: int, value: str, now: datetime) -> bool:
-    cur.execute(
-        """
-        INSERT INTO ns_records (domain_id, value, updated_at)
-        SELECT %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM ns_records WHERE domain_id = %s AND value = %s
-        )
-        """,
-        (domain_id, value, now, domain_id, value),
+def insert_ns_record(session: Session, domain_id: int, value: str, now: datetime) -> bool:
+    statement = select(NSRecord).where(
+        NSRecord.domain_id == domain_id,
+        NSRecord.value == value,
     )
-    return cur.rowcount == 1
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
+
+    session.add(NSRecord(domain_id=domain_id, value=value, updated_at=now))
+    return True
 
 
 def insert_mx_record(
-    cur: psycopg.Cursor, domain_id: int, exchange: str, priority: int, now: datetime
+    session: Session, domain_id: int, exchange: str, priority: int, now: datetime
 ) -> bool:
-    cur.execute(
-        """
-        INSERT INTO mx_records (domain_id, exchange, priority, updated_at)
-        SELECT %s, %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM mx_records
-            WHERE domain_id = %s AND exchange = %s AND COALESCE(priority, -1) = COALESCE(%s, -1)
+    statement = select(MXRecord).where(
+        MXRecord.domain_id == domain_id,
+        MXRecord.exchange == exchange,
+        MXRecord.priority == priority,
+    )
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
+
+    session.add(
+        MXRecord(
+            domain_id=domain_id,
+            exchange=exchange,
+            priority=priority,
+            updated_at=now,
         )
-        """,
-        (domain_id, exchange, priority, now, domain_id, exchange, priority),
     )
-    return cur.rowcount == 1
+    return True
 
 
-def insert_soa_record(cur: psycopg.Cursor, domain_id: int, value: str, now: datetime) -> bool:
-    cur.execute(
-        """
-        INSERT INTO soa_records (domain_id, value, updated_at)
-        SELECT %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM soa_records WHERE domain_id = %s AND value = %s
-        )
-        """,
-        (domain_id, value, now, domain_id, value),
+def insert_soa_record(session: Session, domain_id: int, value: str, now: datetime) -> bool:
+    statement = select(SoaRecord).where(
+        SoaRecord.domain_id == domain_id,
+        SoaRecord.value == value,
     )
-    return cur.rowcount == 1
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
+
+    session.add(SoaRecord(domain_id=domain_id, value=value, updated_at=now))
+    return True
 
 
-def insert_cname_record(cur: psycopg.Cursor, domain_id: int, target: str, now: datetime) -> bool:
-    cur.execute(
-        """
-        INSERT INTO cname_records (domain_id, target, updated_at)
-        SELECT %s, %s, %s
-        WHERE NOT EXISTS (
-            SELECT 1 FROM cname_records WHERE domain_id = %s AND target = %s
-        )
-        """,
-        (domain_id, target, now, domain_id, target),
+def insert_cname_record(session: Session, domain_id: int, target: str, now: datetime) -> bool:
+    statement = select(CNAMERecord).where(
+        CNAMERecord.domain_id == domain_id,
+        CNAMERecord.target == target,
     )
-    return cur.rowcount == 1
+    existing = session.exec(statement).one_or_none()
+    if existing:
+        return False
+
+    session.add(CNAMERecord(domain_id=domain_id, target=target, updated_at=now))
+    return True
 
 
-def update_domain_timestamp(cur: psycopg.Cursor, domain_id: int, now: datetime) -> None:
-    cur.execute(
-        """
-        UPDATE domains
-        SET updated_at = %s
-        WHERE id = %s
-        """,
-        (now, domain_id),
-    )
-
-
-def process_record(cur: psycopg.Cursor, payload: Dict[str, Any], line_no: int) -> bool:
+def process_record(session: Session, payload: Dict[str, Any], line_no: int) -> bool:
     domain = payload.get("query_name", "").lower().strip(".")
     if not domain:
         print(f"[WARNING] Line {line_no}: missing query_name")
@@ -189,26 +160,26 @@ def process_record(cur: psycopg.Cursor, payload: Dict[str, Any], line_no: int) -
         return False
 
     now = utcnow()
-    domain_id = ensure_domain(cur, domain, now)
+    domain_obj = ensure_domain(session, domain, now)
 
     inserted = False
 
     if record_type == "A":
         value = str(data).lower().strip(".")
         if value:
-            inserted = insert_a_record(cur, domain_id, value, now)
+            inserted = insert_a_record(session, domain_obj.id, value, now)
     elif record_type == "AAAA":
         value = str(data).lower().strip(".")
         if value:
-            inserted = insert_aaaa_record(cur, domain_id, value, now)
+            inserted = insert_aaaa_record(session, domain_obj.id, value, now)
     elif record_type == "CNAME":
         target = str(data).lower().strip(".")
         if target:
-            inserted = insert_cname_record(cur, domain_id, target, now)
+            inserted = insert_cname_record(session, domain_obj.id, target, now)
     elif record_type == "NS":
         value = str(data).lower().strip(".")
         if value and "root-servers.net" not in value and "gtld-servers.net" not in value:
-            inserted = insert_ns_record(cur, domain_id, value, now)
+            inserted = insert_ns_record(session, domain_obj.id, value, now)
     elif record_type == "MX":
         parts = str(data).split()
         if len(parts) >= 2:
@@ -217,17 +188,13 @@ def process_record(cur: psycopg.Cursor, payload: Dict[str, Any], line_no: int) -
             except ValueError:
                 priority = 0
             exchange = parts[1].lower().strip(".")
-            inserted = insert_mx_record(cur, domain_id, exchange, priority, now)
+            inserted = insert_mx_record(session, domain_obj.id, exchange, priority, now)
     elif record_type == "SOA":
         value = str(data).lower().strip(".")
         if value:
-            inserted = insert_soa_record(cur, domain_id, value, now)
+            inserted = insert_soa_record(session, domain_obj.id, value, now)
     else:
         print(f"[INFO] Line {line_no}: unsupported record type {record_type}; skipping")
-
-    if inserted:
-        update_domain_timestamp(cur, domain_id, now)
-        print(f"INFO: updated {record_type} record for domain {domain}")
 
     return inserted
 
@@ -251,31 +218,30 @@ def build_arg_parser() -> argparse.ArgumentParser:
 
 def main() -> None:
     args = build_arg_parser().parse_args()
-    postgres_dsn = resolve_dsn(args.postgres_dsn)
+    postgres_dsn = resolve_sync_dsn(args.postgres_dsn)
 
     total_processed = 0
     total_inserted = 0
 
-    with psycopg.connect(postgres_dsn) as conn:
-        with conn.cursor() as cur:
-            with args.input.open("r", encoding="utf-8") as handle:
-                for line_no, raw in enumerate(handle, start=1):
-                    line = raw.strip()
-                    if not line:
-                        continue
+    with session_scope(dsn=postgres_dsn) as session:
+        with args.input.open("r", encoding="utf-8") as handle:
+            for line_no, raw in enumerate(handle, start=1):
+                line = raw.strip()
+                if not line:
+                    continue
 
-                    try:
-                        payload = json.loads(line)
-                    except json.JSONDecodeError as exc:
-                        print(f"[ERROR] Line {line_no}: invalid JSON ({exc})")
-                        continue
+                try:
+                    payload = json.loads(line)
+                except json.JSONDecodeError as exc:
+                    print(f"[ERROR] Line {line_no}: invalid JSON ({exc})")
+                    continue
 
-                    changed = process_record(cur, payload, line_no)
-                    conn.commit()
+                changed = process_record(session, payload, line_no)
+                session.commit()
 
-                    total_processed += 1
-                    if changed:
-                        total_inserted += 1
+                total_processed += 1
+                if changed:
+                    total_inserted += 1
 
     print(
         f"[INFO] Processed {total_processed} records; "

--- a/tools/sqlmodel_helpers.py
+++ b/tools/sqlmodel_helpers.py
@@ -1,0 +1,90 @@
+"""Shared SQLModel helpers for synchronous tooling scripts."""
+
+from __future__ import annotations
+
+import os
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Dict, Iterator, Optional
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, create_engine
+
+ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
+_ENGINE_CACHE: Dict[str, Engine] = {}
+
+
+def _parse_env_file(path: Path) -> Dict[str, str]:
+    env_vars: Dict[str, str] = {}
+    if not path.exists():
+        return env_vars
+
+    with path.open("r", encoding="utf-8") as handle:
+        for raw_line in handle:
+            line = raw_line.strip()
+            if not line or line.startswith("#") or "=" not in line:
+                continue
+            key, value = line.split("=", 1)
+            env_vars[key.strip()] = value.strip().strip('\"\'')
+    return env_vars
+
+
+def normalise_sync_dsn(dsn: str) -> str:
+    """Normalise DSNs so SQLAlchemy uses the psycopg driver."""
+
+    if dsn.startswith("postgresql+asyncpg://"):
+        return "postgresql+psycopg://" + dsn[len("postgresql+asyncpg://") :]
+    if dsn.startswith("postgresql://"):
+        return "postgresql+psycopg://" + dsn[len("postgresql://") :]
+    if dsn.startswith("postgresql+psycopg://"):
+        return dsn
+    if "://" not in dsn:
+        return f"postgresql+psycopg://{dsn}"
+    return dsn
+
+
+def resolve_sync_dsn(explicit: Optional[str] = None) -> str:
+    """Resolve a PostgreSQL DSN for synchronous SQLModel scripts."""
+
+    if explicit:
+        dsn = explicit
+    elif "POSTGRES_DSN" in os.environ:
+        dsn = os.environ["POSTGRES_DSN"]
+    else:
+        env_vars = _parse_env_file(ENV_PATH)
+        dsn = env_vars.get("POSTGRES_DSN")
+
+    if not dsn:
+        raise ValueError("POSTGRES_DSN not provided via flag, env var, or .env file")
+
+    return normalise_sync_dsn(dsn)
+
+
+def get_engine(dsn: str) -> Engine:
+    """Return (and cache) a synchronous SQLModel engine for the DSN."""
+
+    normalised = normalise_sync_dsn(dsn)
+    engine = _ENGINE_CACHE.get(normalised)
+    if engine is None:
+        engine = create_engine(
+            normalised,
+            echo=False,
+            pool_pre_ping=True,
+            pool_recycle=3600,
+            future=True,
+        )
+        _ENGINE_CACHE[normalised] = engine
+    return engine
+
+
+@contextmanager
+def session_scope(*, dsn: Optional[str] = None, engine: Optional[Engine] = None) -> Iterator[Session]:
+    """Context manager yielding a SQLModel session tied to the given DSN/engine."""
+
+    if engine is None:
+        if dsn is None:
+            raise ValueError("Either dsn or engine must be provided")
+        engine = get_engine(dsn)
+
+    with Session(engine) as session:
+        yield session


### PR DESCRIPTION
## Summary
- add a shared SQLModel helper for DSN resolution and engine/session management in tooling scripts
- refactor import scripts to use SQLModel sessions and models instead of psycopg cursors
- update the screenshot scraper to rely on SQLModel queries for selecting and updating domains

## Testing
- python -m compileall tools/import_domains.py tools/import_ip.py tools/import_records.py tools/screenshot_scraper.py tools/sqlmodel_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dbd8e7e80c832381c82603103b2473