### PR TITLE
Require explicit PostgreSQL DSN for tools scripts

### DIFF
--- a/tools/add_qrcode_column.py
+++ b/tools/add_qrcode_column.py
@@ -1,79 +1,54 @@
 #!/usr/bin/env python3
 
+"""Utility script to add the qrcode column to the domains table."""
+
+import argparse
 import asyncio
-import os
-from pathlib import Path
+
 import asyncpg
 
 
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
-def _parse_env_file(path: Path) -> dict:
-    """Parse a .env file and return key-value pairs."""
-    env_vars = {}
-    if not path.exists():
-        return env_vars
-    
-    with open(path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-    # First try environment variables
-    if "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        # Try to load from .env file
-        env_vars = _parse_env_file(ENV_PATH)
-        dsn = env_vars.get("POSTGRES_DSN")
-        
-        if not dsn:
-            raise ValueError(
-                "POSTGRES_DSN not found in environment or .env file"
-            )
-    
-    # Convert SQLAlchemy DSN to asyncpg format
-    if dsn.startswith("postgresql+asyncpg://"):
-        return "postgresql://" + dsn[len("postgresql+asyncpg://"):]
-    if dsn.startswith("postgresql+psycopg://"):
-        return "postgresql://" + dsn[len("postgresql+psycopg://"):]
-    return dsn
-
-
-async def add_qrcode_column():
-    """Add the qrcode column to the domains table."""
-    postgres_dsn = resolve_dsn()
+async def add_qrcode_column(postgres_dsn: str) -> None:
+    """Add the qrcode column to the domains table if missing."""
     conn = await asyncpg.connect(postgres_dsn)
-    
+
     try:
-        # Check if qrcode column exists
-        exists = await conn.fetchval("""
+        exists = await conn.fetchval(
+            """
             SELECT EXISTS (
                 SELECT 1 FROM information_schema.columns
                 WHERE table_name = 'domains' AND column_name = 'qrcode'
             )
-        """)
-        
+            """
+        )
+
         if not exists:
-            # Add the qrcode column
             await conn.execute("ALTER TABLE domains ADD COLUMN qrcode TEXT")
             print("[SUCCESS] Added qrcode column to domains table")
         else:
             print("[INFO] QR code column already exists")
-            
-    except Exception as e:
-        print(f"[ERROR] Failed to add qrcode column: {e}")
+
+    except Exception as exc:  # pragma: no cover - defensive logging
+        print(f"[ERROR] Failed to add qrcode column: {exc}")
         raise
     finally:
         await conn.close()
 
 
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Add qrcode column")
+    parser.add_argument(
+        "--postgres-dsn",
+        required=True,
+        help="PostgreSQL DSN",
+    )
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    asyncio.run(add_qrcode_column(args.postgres_dsn))
+
+
 if __name__ == "__main__":
-    asyncio.run(add_qrcode_column())
+    main()

--- a/tools/decode_idna.py
+++ b/tools/decode_idna.py
@@ -2,56 +2,13 @@
 
 import asyncio
 import idna
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import List, Tuple
 
 import asyncpg
 import click
 
 from idna.core import IDNAError
-
-
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
-def _parse_env_file(path: Path) -> dict:
-    """Parse a .env file and return key-value pairs."""
-    env_vars = {}
-    if not path.exists():
-        return env_vars
-
-    with open(path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-    # First try environment variables
-    if "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        # Try to load from .env file
-        env_vars = _parse_env_file(ENV_PATH)
-        dsn = env_vars.get("POSTGRES_DSN")
-
-        if not dsn:
-            raise ValueError(
-                "POSTGRES_DSN not found in environment or .env file"
-            )
-
-    # Convert SQLAlchemy DSN to asyncpg format
-    if dsn.startswith("postgresql+asyncpg://"):
-        return "postgresql://" + dsn[len("postgresql+asyncpg://"):]
-    if dsn.startswith("postgresql+psycopg://"):
-        return "postgresql://" + dsn[len("postgresql+psycopg://"):]
-    return dsn
 
 
 def utcnow() -> datetime:
@@ -140,14 +97,18 @@ async def process_idna_domains(postgres_dsn: str) -> None:
 
 
 @click.command()
-def main():
+@click.option(
+    "--postgres-dsn",
+    required=True,
+    type=str,
+    help="PostgreSQL DSN",
+)
+def main(postgres_dsn: str):
     """IDNA decoder tool with PostgreSQL backend.
 
     Finds domains with IDNA encoding (containing 'xn--') and decodes them
     to their Unicode representation, updating the database accordingly.
     """
-    postgres_dsn = resolve_dsn()
-
     click.echo("[INFO] Starting IDNA domain decoding")
 
     asyncio.run(process_idna_domains(postgres_dsn))

--- a/tools/extract_certstream.py
+++ b/tools/extract_certstream.py
@@ -14,11 +14,8 @@ bootstrap.setup()
 
 import asyncio
 import logging
-import os
 import sys
 from datetime import datetime
-from pathlib import Path
-from typing import Optional
 
 import certstream
 import click
@@ -28,42 +25,6 @@ from sqlmodel import select
 from sqlmodel.ext.asyncio.session import AsyncSession
 
 from shared.models.postgres import Domain
-
-
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
-def _parse_env_file(path: Path) -> dict:
-    """Parse a .env file and return key-value pairs."""
-    env_vars = {}
-    if not path.exists():
-        return env_vars
-
-    with open(path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-    # First try environment variables
-    if "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        # Try to load from .env file
-        env_vars = _parse_env_file(ENV_PATH)
-        dsn = env_vars.get("POSTGRES_DSN")
-
-        if not dsn:
-            raise ValueError(
-                "POSTGRES_DSN not found in environment or .env file"
-            )
-
-    return dsn
 
 
 class PostgresAsync:
@@ -164,14 +125,14 @@ def create_callback(postgres_dsn: str):
     '--postgres-dsn',
     help='PostgreSQL DSN (e.g., postgresql+asyncpg://user:pass@host/db)',
     type=str,
-    default=None
+    required=True,
 )
 @click.option(
     '--verbose', '-v',
     is_flag=True,
     help='Enable verbose logging'
 )
-def main(postgres_dsn: Optional[str], verbose: bool):
+def main(postgres_dsn: str, verbose: bool):
     """Certificate Transparency log monitor for PostgreSQL."""
     # Configure logging
     log_level = logging.DEBUG if verbose else logging.INFO
@@ -179,21 +140,6 @@ def main(postgres_dsn: Optional[str], verbose: bool):
         format='[%(levelname)s:%(name)s] %(asctime)s - %(message)s',
         level=log_level
     )
-
-    # Use settings or .env file if no explicit DSN provided
-    if not postgres_dsn:
-        try:
-            postgres_dsn = resolve_dsn()
-        except ValueError as exc:
-            click.echo(f"[ERROR] {exc}")
-            click.echo("[INFO] Please set POSTGRES_DSN in environment or "
-                       ".env file")
-            click.echo("[INFO] Example: POSTGRES_DSN=postgresql+asyncpg://"
-                       "user:pass@localhost:5432/dbname")
-            sys.exit(1)
-        except Exception as exc:
-            click.echo(f"[ERROR] Could not resolve PostgreSQL DSN: {exc}")
-            sys.exit(1)
 
     click.echo("[INFO] Starting Certificate Transparency monitor...")
     click.echo(f"[INFO] PostgreSQL DSN: {postgres_dsn}")

--- a/tools/extract_header.py
+++ b/tools/extract_header.py
@@ -9,13 +9,9 @@ import logging
 import math
 import multiprocessing
 import os
-import re
-import socket
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import AsyncIterator, Dict, List, Optional, Set, Tuple
-from urllib.parse import urlsplit, urlunsplit
 
 import aio_pika
 from aio_pika import DeliveryMode, Message
@@ -31,157 +27,7 @@ DEFAULT_PREFETCH = 400
 DEFAULT_CONCURRENCY = 200
 DEFAULT_TIMEOUT = 5.0
 DEFAULT_SCHEMES: Tuple[str, ...] = ("http", "https")
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
 log = logging.getLogger("extract_header")
-
-
-_ENV_VAR_PATTERN = re.compile(r"\$(?:\{([^}]+)\}|([A-Za-z0-9_]+))")
-
-
-def _parse_env_file(path: Path) -> dict[str, str]:
-    """Parse environment variables from .env file."""
-    env_vars: dict[str, str] = {}
-    if not path.exists():
-        return env_vars
-
-    with open(path, encoding="utf-8") as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def _expand_env_vars(value: str, env_values: dict[str, str]) -> str:
-    """Expand $VAR and ${VAR} references using the provided environment mapping."""
-
-    if not value:
-        return value
-
-    def _replace(match: re.Match[str]) -> str:
-        key = match.group(1) or match.group(2)
-        if key in env_values:
-            return env_values[key]
-        upper_key = key.upper()
-        if upper_key in env_values:
-            return env_values[upper_key]
-        lower_key = key.lower()
-        if lower_key in env_values:
-            return env_values[lower_key]
-        return match.group(0)
-
-    return _ENV_VAR_PATTERN.sub(_replace, value)
-
-
-def _resolve_port_token(token: str, env_values: dict[str, str]) -> Optional[int]:
-    """Resolve the port token to an integer value.
-
-    The token can be a numeric string, a service name (looked up using
-    :func:`socket.getservbyname`), or a reference to another environment value.
-    """
-
-    candidates = (
-        token,
-        token.upper(),
-        token.lower(),
-    )
-
-    for candidate in candidates:
-        value = env_values.get(candidate)
-        if value and value.isdigit():
-            return int(value)
-
-    if token.isdigit():
-        return int(token)
-
-    try:
-        return socket.getservbyname(token.lower(), "tcp")
-    except OSError:
-        return None
-
-
-def _normalize_postgres_dsn(dsn: str, env_values: dict[str, str]) -> str:
-    """Expand environment references and normalise the PostgreSQL DSN."""
-
-    expanded = _expand_env_vars(dsn, env_values)
-
-    try:
-        parts = urlsplit(expanded)
-    except ValueError:
-        return expanded
-
-    if not parts.netloc:
-        return expanded
-
-    userinfo = ""
-    hostinfo = parts.netloc
-    if "@" in hostinfo:
-        userinfo, hostinfo = hostinfo.rsplit("@", 1)
-
-    host = hostinfo
-    port_token: Optional[str] = None
-
-    if hostinfo.startswith("["):
-        if "]" in hostinfo:
-            end = hostinfo.index("]")
-            host = hostinfo[: end + 1]
-            remainder = hostinfo[end + 1 :]
-            if remainder.startswith(":"):
-                port_token = remainder[1:]
-        else:
-            host = hostinfo
-    else:
-        if ":" in hostinfo:
-            host, port_token = hostinfo.rsplit(":", 1)
-
-    if port_token:
-        resolved_port = _resolve_port_token(port_token, env_values)
-        if resolved_port is None:
-            raise RuntimeError(
-                "Invalid port value in POSTGRES_DSN: "
-                f"{port_token!r}. Provide a numeric port or a known service name."
-            )
-        hostinfo = f"{host}:{resolved_port}"
-    else:
-        hostinfo = host
-
-    if userinfo:
-        netloc = f"{userinfo}@{hostinfo}"
-    else:
-        netloc = hostinfo
-
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-
-    file_values = _parse_env_file(ENV_PATH)
-    combined_env = {**file_values, **os.environ}
-
-    env_value = os.environ.get("POSTGRES_DSN")
-    if env_value:
-        dsn = env_value
-    else:
-        dsn = file_values.get("POSTGRES_DSN")
-
-    if not dsn:
-        raise RuntimeError(
-            "POSTGRES_DSN must be set as an environment variable "
-            "or in .env file"
-        )
-
-    normalized = _normalize_postgres_dsn(dsn, combined_env)
-
-    # Convert SQLAlchemy DSN to asyncpg format
-    if normalized.startswith("postgresql+asyncpg://"):
-        return "postgresql://" + normalized[len("postgresql+asyncpg://"):]
-    if normalized.startswith("postgresql+psycopg://"):
-        return "postgresql://" + normalized[len("postgresql+psycopg://"):]
-    return normalized
 
 
 def utcnow() -> datetime:
@@ -692,6 +538,9 @@ def run_worker_direct(settings: DirectWorkerSettings) -> str:
 
 @click.command()
 @click.option(
+    "--postgres-dsn", type=str, required=True, help="PostgreSQL DSN"
+)
+@click.option(
     "--worker", "-w", type=int, default=4, show_default=True,
     help="Worker processes"
 )
@@ -731,6 +580,7 @@ def run_worker_direct(settings: DirectWorkerSettings) -> str:
     "--verbose", is_flag=True, help="Enable verbose debug logging"
 )
 def main(
+    postgres_dsn: str,
     worker: int,
     concurrency: int,
     request_timeout: float,
@@ -749,9 +599,6 @@ def main(
     concurrency = max(1, concurrency)
     prefetch = max(1, prefetch)
     
-    # Get PostgreSQL DSN from environment
-    postgres_dsn = resolve_dsn()
-
     base_settings = WorkerSettings(
         postgres_dsn=postgres_dsn,
         rabbitmq_url=rabbitmq_url,

--- a/tools/extract_whois.py
+++ b/tools/extract_whois.py
@@ -1,165 +1,18 @@
 #!/usr/bin/env python3
 
-import multiprocessing
-import os
-import re
 import asyncio
-import socket
+import multiprocessing
 from datetime import datetime, timezone
-from pathlib import Path
-from typing import List, Dict, Any, Optional
-from urllib.parse import urlsplit, urlunsplit
+from typing import Any, Dict, List, Optional
 
-from ipwhois.net import Net
 from ipwhois.asn import IPASN
+from ipwhois.net import Net
 
 import asyncpg
 import click
 
 
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
 BATCH_SIZE = 100  # how many records each worker processes at once
-
-
-_ENV_VAR_PATTERN = re.compile(r"\$(?:\{([^}]+)\}|([A-Za-z0-9_]+))")
-
-
-def _parse_env_file(path: Path) -> Dict[str, str]:
-    """Parse a .env file and return key-value pairs."""
-    env_vars = {}
-    if not path.exists():
-        return env_vars
-    
-    with open(path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def _expand_env_vars(value: str, env_values: Dict[str, str]) -> str:
-    """Expand $VAR and ${VAR} references using available environment values."""
-
-    if not value:
-        return value
-
-    def _replace(match: "re.Match[str]") -> str:
-        key = match.group(1) or match.group(2)
-        if key in env_values:
-            return env_values[key]
-        upper_key = key.upper()
-        if upper_key in env_values:
-            return env_values[upper_key]
-        lower_key = key.lower()
-        if lower_key in env_values:
-            return env_values[lower_key]
-        return match.group(0)
-
-    return _ENV_VAR_PATTERN.sub(_replace, value)
-
-
-def _resolve_port_token(token: str, env_values: Dict[str, str]) -> Optional[int]:
-    """Resolve a DSN port token to an integer value."""
-
-    candidates = (
-        token,
-        token.upper(),
-        token.lower(),
-    )
-
-    for candidate in candidates:
-        value = env_values.get(candidate)
-        if value and value.isdigit():
-            return int(value)
-
-    if token.isdigit():
-        return int(token)
-
-    try:
-        return socket.getservbyname(token.lower(), "tcp")
-    except OSError:
-        return None
-
-
-def _normalize_postgres_dsn(dsn: str, env_values: Dict[str, str]) -> str:
-    """Normalize the PostgreSQL DSN by expanding env vars and resolving ports."""
-
-    expanded = _expand_env_vars(dsn, env_values)
-
-    try:
-        parts = urlsplit(expanded)
-    except ValueError:
-        return expanded
-
-    if not parts.netloc:
-        return expanded
-
-    userinfo = ""
-    hostinfo = parts.netloc
-
-    if "@" in hostinfo:
-        userinfo, hostinfo = hostinfo.rsplit("@", 1)
-
-    host = hostinfo
-    port_token: Optional[str] = None
-
-    if hostinfo.startswith("["):
-        if "]" in hostinfo:
-            end = hostinfo.index("]")
-            host = hostinfo[: end + 1]
-            remainder = hostinfo[end + 1 :]
-            if remainder.startswith(":"):
-                port_token = remainder[1:]
-        else:
-            host = hostinfo
-    else:
-        if ":" in hostinfo:
-            host, port_token = hostinfo.rsplit(":", 1)
-
-    if port_token:
-        resolved_port = _resolve_port_token(port_token, env_values)
-        if resolved_port is None:
-            raise ValueError(
-                "Invalid port value in POSTGRES_DSN: "
-                f"{port_token!r}. Provide a numeric port or a known service name."
-            )
-        hostinfo = f"{host}:{resolved_port}"
-    else:
-        hostinfo = host
-
-    if userinfo:
-        netloc = f"{userinfo}@{hostinfo}"
-    else:
-        netloc = hostinfo
-
-    return urlunsplit((parts.scheme, netloc, parts.path, parts.query, parts.fragment))
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-
-    file_values = _parse_env_file(ENV_PATH)
-    combined_env: Dict[str, str] = {**file_values, **os.environ}
-
-    if "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        dsn = file_values.get("POSTGRES_DSN")
-        if not dsn:
-            raise ValueError(
-                "POSTGRES_DSN not found in environment or .env file"
-            )
-
-    normalized = _normalize_postgres_dsn(dsn, combined_env)
-
-    # Convert SQLAlchemy DSN to asyncpg format
-    if normalized.startswith("postgresql+asyncpg://"):
-        return "postgresql://" + normalized[len("postgresql+asyncpg://"):]
-    if normalized.startswith("postgresql+psycopg://"):
-        return "postgresql://" + normalized[len("postgresql+psycopg://"):]
-    return normalized
 
 
 def utcnow() -> datetime:
@@ -361,6 +214,12 @@ async def initialize_database(postgres_dsn: str) -> None:
 
 @click.command()
 @click.option(
+    "--postgres-dsn",
+    type=str,
+    required=True,
+    help="PostgreSQL DSN",
+)
+@click.option(
     "--workers",
     type=int,
     default=4,
@@ -372,13 +231,11 @@ async def initialize_database(postgres_dsn: str) -> None:
     default=BATCH_SIZE,
     help="Number of domains per worker batch"
 )
-def main(workers: int, batch_size: int):
+def main(postgres_dsn: str, workers: int, batch_size: int):
     """WHOIS extraction tool with PostgreSQL backend.
     
     Fetches WHOIS information for domains with A records.
     """
-    postgres_dsn = resolve_dsn()
-    
     click.echo("[INFO] Starting WHOIS fetcher")
     click.echo(f"[INFO] Workers: {workers}, Batch size: {batch_size}")
     

--- a/tools/insert_asn.py
+++ b/tools/insert_asn.py
@@ -1,54 +1,11 @@
 #!/usr/bin/env python3
 
 import asyncio
-import os
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import List
 
 import asyncpg
 import click
-
-
-ENV_PATH = Path(__file__).resolve().parents[1] / ".env"
-
-
-def _parse_env_file(path: Path) -> dict:
-    """Parse a .env file and return key-value pairs."""
-    env_vars = {}
-    if not path.exists():
-        return env_vars
-
-    with open(path, 'r') as f:
-        for line in f:
-            line = line.strip()
-            if line and not line.startswith('#') and '=' in line:
-                key, value = line.split('=', 1)
-                env_vars[key.strip()] = value.strip().strip('"\'')
-    return env_vars
-
-
-def resolve_dsn() -> str:
-    """Resolve PostgreSQL DSN from environment or .env file."""
-    # First try environment variables
-    if "POSTGRES_DSN" in os.environ:
-        dsn = os.environ["POSTGRES_DSN"]
-    else:
-        # Try to load from .env file
-        env_vars = _parse_env_file(ENV_PATH)
-        dsn = env_vars.get("POSTGRES_DSN")
-
-        if not dsn:
-            raise ValueError(
-                "POSTGRES_DSN not found in environment or .env file"
-            )
-
-    # Convert SQLAlchemy DSN to asyncpg format
-    if dsn.startswith("postgresql+asyncpg://"):
-        return "postgresql://" + dsn[len("postgresql+asyncpg://"):]
-    if dsn.startswith("postgresql+psycopg://"):
-        return "postgresql://" + dsn[len("postgresql+psycopg://"):]
-    return dsn
 
 
 def utcnow() -> datetime:
@@ -152,15 +109,19 @@ async def process_asns(postgres_dsn: str, input_file: str) -> None:
     required=True,
     help="Input file containing CIDR/ASN pairs (e.g., '1.0.0.0/24 13335')"
 )
-def main(input: str):
+@click.option(
+    "--postgres-dsn",
+    required=True,
+    type=str,
+    help="PostgreSQL DSN",
+)
+def main(input: str, postgres_dsn: str):
     """ASN insertion tool with PostgreSQL backend.
 
     Loads CIDR/ASN pairs from a text file and inserts them into PostgreSQL.
     Each line should contain a CIDR block and ASN number separated by
     whitespace. Lines starting with ';' are treated as comments and skipped.
     """
-    postgres_dsn = resolve_dsn()
-
     click.echo("[INFO] Starting ASN insertion")
     click.echo(f"[INFO] Input file: {input}")
 


### PR DESCRIPTION
## Summary
- replace environment-based DSN resolution in assorted tools with explicit `--postgres-dsn` arguments
- update worker entry points to pass the CLI-supplied DSN throughout database helpers
- simplify the add_qrcode_column utility to use argparse with a required DSN flag

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dc217aa2c08323a5d4d466bfa291d0