### PR TITLE
Fix asyncpg DSN generation for passwords with special characters

### DIFF
--- a/tests/tools/test_async_sqlmodel_helpers.py
+++ b/tests/tools/test_async_sqlmodel_helpers.py
@@ -1,0 +1,19 @@
+from tools.async_sqlmodel_helpers import asyncpg_pool_dsn
+
+
+def test_asyncpg_pool_dsn_strips_async_driver():
+    dsn = "postgresql+asyncpg://user:password@localhost/db"
+
+    assert (
+        asyncpg_pool_dsn(dsn)
+        == "postgresql://user:password@localhost/db"
+    )
+
+
+def test_asyncpg_pool_dsn_preserves_plus_sign_in_password():
+    dsn = "postgresql+asyncpg://user:pass+word@localhost/db"
+
+    assert (
+        asyncpg_pool_dsn(dsn)
+        == "postgresql://user:pass+word@localhost/db"
+    )

--- a/tools/async_sqlmodel_helpers.py
+++ b/tools/async_sqlmodel_helpers.py
@@ -51,7 +51,8 @@ def asyncpg_pool_dsn(dsn: str) -> str:
         raise RuntimeError("Invalid POSTGRES_DSN configuration") from exc
 
     drivername = url.drivername.split("+", 1)[0]
-    return str(url.set(drivername=drivername))
+    updated_url = url.set(drivername=drivername)
+    return updated_url.render_as_string(hide_password=False)
 
 
 def resolve_async_dsn(explicit: Optional[str] = None) -> str:


### PR DESCRIPTION
## Summary
- ensure asyncpg DSN conversion retains the original password while dropping the async driver prefix
- add regression tests covering driver stripping and passwords containing plus signs

## Testing
- pytest tests/tools/test_async_sqlmodel_helpers.py

------
https://chatgpt.com/codex/tasks/task_e_68dcc99e3ef483239445d233baf60618