### PR TITLE
Fix banner grabber bulk update primary key binding

### DIFF
--- a/tools/banner_grabber.py
+++ b/tools/banner_grabber.py
@@ -222,6 +222,7 @@ async def persist_batch_results(
             if successes:
                 params = [
                     {
+                        "id": domain_id,
                         "domain_id": domain_id,
                         "banner": banner,
                         "updated_at": now,
@@ -230,7 +231,7 @@ async def persist_batch_results(
                 ]
                 stmt = (
                     update(Domain)
-                    .where(Domain.id == bindparam("domain_id"))
+                    .where(Domain.id == bindparam("id"))
                     .values(
                         banner=bindparam("banner"),
                         updated_at=bindparam("updated_at"),


### PR DESCRIPTION
## Summary
- include primary key values in banner grabber bulk updates so SQLAlchemy can apply updates

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd3dd44188323be1ba8970232b872